### PR TITLE
fix: Update Go version retrieval logic (#1262)

### DIFF
--- a/scripts/make/100_go.mk
+++ b/scripts/make/100_go.mk
@@ -1,4 +1,4 @@
-GO_VERSION            := $(shell go list -m -f '{{.GoVersion}}')
+GO_VERSION            := $(shell go mod edit -json | jq -r .Go)
 GO                    := GO111MODULE=on CGO_ENABLED=0 go
 GO_VENDOR             := $(if $(realpath $(ROOTDIR)/vendor/modules.txt),true,false)
 GO_BUILD_COMMON_FLAGS := -trimpath


### PR DESCRIPTION
`go list -m -f '{{.GoVersion}}'` works for standalone modules, but it doesn't work in a Go workspace. In the later case, the command reports the Go version of _all_ modules in the workspace.

`go mod edit -json` on the other hand only reports the versin in the current module. Having to depend on jq like this is not ideal...