### PR TITLE
fix: Unexport ParseConfigArgument

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -209,7 +209,7 @@ linters-settings:
       const:
         COMPANY: Grafana Labs
     template: |-
-      Copyright (C) {{ MOD-YEAR }} {{ COMPANY }}.
+      Copyright (C) {{ MOD-YEAR-RANGE }} {{ COMPANY }}.
       SPDX-License-Identifier: Apache-2.0
 
   gomoddirectives:

--- a/secret.go
+++ b/secret.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Grafana Labs.
+// Copyright (C) 2025-2026 Grafana Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package client implements a k6 extension for accessing Grafana Secrets Management.
@@ -38,7 +38,7 @@ type extConfig struct {
 	RequestsBurst          *int   `json:"requestsBurst"`
 }
 
-func ParseConfigArgument(configArg string) (string, error) {
+func parseConfigArgument(configArg string) (string, error) {
 	configKey, configPath, ok := strings.Cut(configArg, "=")
 	if !ok || configKey != "config" {
 		return "", errInvalidConfig
@@ -141,7 +141,7 @@ func getConfig(arg string) (extConfig, error) {
 	var config extConfig
 
 	// Parse the ConfigArgument to get the config file path
-	configPath, err := ParseConfigArgument(arg)
+	configPath, err := parseConfigArgument(arg)
 	if err != nil {
 		return config, err
 	}

--- a/secret_test.go
+++ b/secret_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Grafana Labs.
+// Copyright (C) 2025-2026 Grafana Labs.
 // SPDX-License-Identifier: Apache-2.0
 
 package client
@@ -176,10 +176,10 @@ func TestParseConfigArgument(t *testing.T) {
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
 
-			gotPath, err := ParseConfigArgument(testcase.configArg)
+			gotPath, err := parseConfigArgument(testcase.configArg)
 			if testcase.wantErr {
 				if err == nil {
-					t.Errorf("ParseConfigArgument() error = nil, wantErr = true")
+					t.Errorf("parseConfigArgument() error = nil, wantErr = true")
 
 					return
 				}
@@ -188,13 +188,13 @@ func TestParseConfigArgument(t *testing.T) {
 			}
 
 			if err != nil {
-				t.Errorf("ParseConfigArgument() unexpected error = %v", err)
+				t.Errorf("parseConfigArgument() unexpected error = %v", err)
 
 				return
 			}
 
 			if gotPath != testcase.wantPath {
-				t.Errorf("ParseConfigArgument() = %q, want %q", gotPath, testcase.wantPath)
+				t.Errorf("parseConfigArgument() = %q, want %q", gotPath, testcase.wantPath)
 			}
 		})
 	}


### PR DESCRIPTION
This is not really part of the public interface, it should not be exported.

Fix goheader configuration to expect either a single year of creation or a range of years between creation and modification.